### PR TITLE
2404 - add translate_column_regex_replace unit test

### DIFF
--- a/cishouseholds/pipeline/high_level_transformations.py
+++ b/cishouseholds/pipeline/high_level_transformations.py
@@ -494,11 +494,13 @@ def translate_freetext_columns(df: DataFrame, translated_values_lookup_df: DataF
 
     translated_values_lookup_df
         is a lookup in the same location as the other lookups specified in the pipeline_config file
-        contains the translated non-null free text fields with unique identifiers  (participant_id, participant_completion_window_id)
+        contains the translated non-null digital_free_text_columns with unique_identifiers  (participant_id, participant_completion_window_id)
 
     needs_translation_df
-        contains the non-null free text fields requiring translation by unique identifiers (participant_id, participant_completion_window_id)
+        contains the non-null digital_free_text_columns requiring translation by unique_identifiers (participant_id, participant_completion_window_id)
     """
+
+    unique_identifiers = ["participant_id", "digital_free_text_columns"]
 
     digital_free_text_columns = [
         "reason_for_not_consenting_1",


### PR DESCRIPTION
Tests a variety of scenarios, testing revealed that the simple patterns currently used are case sensitive. Given the current application the solution to any matching issues should be to amend the multiple choice lookup / translation dictionary rather than build resilience into the function.

## Pre-review checklist

I have ensured that:

- [ ] Code runs successfully in the development environment.
- [ ] New code is tested to prove that it meets the specificaiton. If not, justify reasoning.
- [ ] New code is documented using [type hinting](https://realpython.com/lessons/type-hinting/) and following the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) docstring format.
- [ ] New code follows the project naming standards.

## Overview of changes

<!---
Add any useful details about your changes here.
-->
