### PR TITLE
CISDP 3011/3012 adding work status options for PHM

### DIFF
--- a/cishouseholds/pipeline/mapping.py
+++ b/cishouseholds/pipeline/mapping.py
@@ -1237,12 +1237,16 @@ category_maps = {
         "work_status_employment": {
             "Currently working. This includes if you are on sick or other leave for less than 4 weeks": 1,
             "Currently not working -  for example on sick or other leave such as maternity or paternity for longer than 4 weeks": 2,  # noqa: E501
+            "Currently not working due to sickness lasting 4 weeks or more": 3,
+            "Currently not working for other reasons such as maternity or paternity lasting 4 weeks or more": 4,
         },
         "work_status_unemployment": {
             "Looking for paid work and able to start": 1,
             "Not looking for paid work. This includes looking after the home or family or not wanting a job or being long-term sick or disabled": 2,  # noqa: E501
             "Retired": 3,
             "Or retired?": 3,
+            "Not looking for paid work due to long-term sickness or disability": 4,
+            "Not looking for paid work for reasons such as looking after the home or family or not wanting a job": 5,
         },
         "work_status_education": {
             "A child aged 4 or over at home-school": 1,

--- a/cishouseholds/pipeline/version_specific_processing/phm_transformations.py
+++ b/cishouseholds/pipeline/version_specific_processing/phm_transformations.py
@@ -36,7 +36,10 @@ def transform_survey_responses_version_phm_delta(df: DataFrame) -> DataFrame:
                 "Employed and currently working",
                 [
                     "Employed",
-                    "Currently working. This includes if you are on sick or other leave for less than 4 weeks",
+                    [
+                        "Currently not working due to sickness lasting 4 weeks or more",
+                        "Currently not working for other reasons such as maternity or paternity lasting 4 weeks or more",
+                    ],
                     None,
                     None,
                 ],
@@ -92,7 +95,10 @@ def transform_survey_responses_version_phm_delta(df: DataFrame) -> DataFrame:
                 [
                     "Not in paid work. This includes being unemployed or retired or doing voluntary work",
                     None,
-                    "Not looking for paid work. This includes looking after the home or family or not wanting a job or being long-term sick or disabled",
+                    [
+                        "Not looking for paid work due to long-term sickness or disability",
+                        "Not looking for paid work for reasons such as looking after the home or family or not wanting a job",
+                    ],
                     # noqa: E501
                     None,
                 ],
@@ -171,7 +177,10 @@ def transform_survey_responses_version_phm_delta(df: DataFrame) -> DataFrame:
                 "Employed and currently not working",
                 [
                     "Employed",
-                    "Currently not working -  for example on sick or other leave such as maternity or paternity for longer than 4 weeks",
+                    [
+                        "Currently not working due to sickness lasting 4 weeks or more",
+                        "Currently not working for other reasons such as maternity or paternity lasting 4 weeks or more",
+                    ],
                     # noqa: E501
                     None,
                     None,
@@ -209,7 +218,10 @@ def transform_survey_responses_version_phm_delta(df: DataFrame) -> DataFrame:
                 [
                     "Not in paid work. This includes being unemployed or retired or doing voluntary work",
                     None,
-                    "Not looking for paid work. This includes looking after the home or family or not wanting a job or being long-term sick or disabled",
+                    [
+                        "Not looking for paid work due to long-term sickness or disability",
+                        "Not looking for paid work for reasons such as looking after the home or family or not wanting a job",
+                    ],
                     None,
                 ],
             ],
@@ -274,7 +286,10 @@ def transform_survey_responses_version_phm_delta(df: DataFrame) -> DataFrame:
                 "Not working (unemployed, retired, long-term sick etc.)",
                 [
                     "Employed",
-                    "Currently not working -  for example on sick or other leave such as maternity or paternity for longer than 4 weeks",
+                    [
+                        "Currently not working due to sickness lasting 4 weeks or more",
+                        "Currently not working for other reasons such as maternity or paternity lasting 4 weeks or more",
+                    ],
                     # noqa: E501
                     None,
                     None,
@@ -315,7 +330,10 @@ def transform_survey_responses_version_phm_delta(df: DataFrame) -> DataFrame:
                 [
                     "Not in paid work. This includes being unemployed or retired or doing voluntary work",
                     None,
-                    "Not looking for paid work. This includes looking after the home or family or not wanting a job or being long-term sick or disabled",
+                    [
+                        "Not looking for paid work due to long-term sickness or disability",
+                        "Not looking for paid work for reasons such as looking after the home or family or not wanting a job",
+                    ],
                     # noqa: E501
                     None,
                 ],


### PR DESCRIPTION
<!---

-->

## Pre-review checklist
1. Added options for employment and unemployment to the output mapping, keeping them separated out as their own answers
2. Added options for employment and unemployment to V0,1,2 work_status mapping into phm_transformations, so that equivalent work statuses in v0, v1 and v2 can be used by analysts, and analysis can be continuous across surveys. 

I have ensured that:

- [ ] Code runs successfully in the development environment.
- [ ] New code is tested to prove that it meets the specificaiton. If not, justify reasoning.
- [ ] New code is documented using [type hinting](https://realpython.com/lessons/type-hinting/) and following the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) docstring format.
- [ ] New code follows the project naming standards.

## Overview of changes

<!---
Add any useful details about your changes here.
-->
