### PR TITLE
Cisdp 3245 - fixing DOB imputation

### DIFF
--- a/cishouseholds/pipeline/demographic_transformations.py
+++ b/cishouseholds/pipeline/demographic_transformations.py
@@ -22,6 +22,7 @@ from cishouseholds.impute import impute_and_flag
 from cishouseholds.impute import impute_by_distribution
 from cishouseholds.impute import impute_by_k_nearest_neighbours
 from cishouseholds.impute import impute_by_mode
+from cishouseholds.impute import impute_date_by_k_nearest_neighbours
 from cishouseholds.impute import merge_previous_imputed_values
 from cishouseholds.merge import left_join_keep_right
 from cishouseholds.pipeline.config import get_config
@@ -343,13 +344,13 @@ def impute_key_columns(df: DataFrame, imputed_value_lookup_df: DataFrame, log_di
         second_imputation_value="Male",
     ).custom_checkpoint()
 
-    # deduplicated_df = impute_and_flag(
-    #     deduplicated_df,
-    #     impute_date_by_k_nearest_neighbours,
-    #     reference_column="date_of_birth",
-    #     donor_group_columns=["region_code", "people_in_household_count_group", "work_status_group"],
-    #     log_file_path=log_directory,
-    # )
+    deduplicated_df = impute_and_flag(
+        deduplicated_df,
+        impute_date_by_k_nearest_neighbours,
+        reference_column="date_of_birth",
+        donor_group_columns=["region_code", "people_in_household_count_group", "work_status_group"],
+        log_file_path=log_directory,
+    )
 
     return deduplicated_df.select(
         unique_id_column,

--- a/cishouseholds/pipeline/pipeline_stages.py
+++ b/cishouseholds/pipeline/pipeline_stages.py
@@ -81,7 +81,6 @@ from cishouseholds.pipeline.validation_schema import validation_schemas
 from cishouseholds.pipeline.version_specific_processing.participant_extract_phm import (
     transform_participant_extract_phm,
 )  # noqa: F401
-from cishouseholds.pipeline.version_specific_processing.phm_transformations import phm_visit_transformations
 from cishouseholds.pipeline.visit_transformations import visit_transformations
 from cishouseholds.prediction_checker_class import PredictionChecker
 from cishouseholds.pyspark_utils import get_or_create_spark_session
@@ -563,8 +562,8 @@ def union_survey_response_files(tables_to_process: List, output_survey_table: st
     return {"output_survey_table": output_survey_table}
 
 
-@register_pipeline_stage("union_historical_visit_transformations")
-def union_historical_visit_transformations(tables_to_process: List, output_survey_table: str, transformations: List):
+@register_pipeline_stage("union_historical_visits")
+def union_historical_visits(tables_to_process: List, output_survey_table: str):
     """
     Union list of tables_to_process, and write to table.
 
@@ -578,15 +577,7 @@ def union_historical_visit_transformations(tables_to_process: List, output_surve
         transformation functions to be applied once the union has taken place
     """
     df_list = [extract_from_table(table) for table in tables_to_process]
-
-    transformations_dict: Dict[str, Any]
-    transformations_dict = {
-        "phm_visit_transformations": phm_visit_transformations,
-    }
-
     df = union_multiple_tables(df_list)
-    for transformation in transformations:
-        df = transformations_dict[transformation](df)
     update_table(df, output_survey_table, "overwrite", survey_table=True)
     return {"output_survey_table": output_survey_table}
 
@@ -783,7 +774,6 @@ def join_lookup_table(
         "blood_past_positive": blood_past_positive_transformations,
         "design_weights_lookup": design_weights_lookup_transformations,
         "ordered_household_id": ordered_household_id_tranformations,
-        "phm_visit_transformation": phm_visit_transformations,
         "participant_extract_phm": clean_participant_extract_phm,
     }
 

--- a/cishouseholds/pipeline/version_specific_processing/phm_transformations.py
+++ b/cishouseholds/pipeline/version_specific_processing/phm_transformations.py
@@ -43,12 +43,6 @@ def phm_transformations(df: DataFrame) -> DataFrame:
     return df
 
 
-def phm_visit_transformations(df: DataFrame) -> DataFrame:
-    """derives visit based fields, must have participant info and historical visits joined prior to transformations"""
-    df = visit_transformations(df)
-    return df
-
-
 def pre_processing(df: DataFrame) -> DataFrame:
     """
     Sets categories to map for digital specific variables to Voyager 0/1/2 equivalent


### PR DESCRIPTION
<!---
Note: Your PR request title must start with the Jira ticket number and concisely describe your changes.
For example: "123 Added function to calculate age on a given date"
-->

## Pre-review checklist
Refactored how the visit_transformation stage runs
Separated out the union so it happens on its own before any tranformations
The union must happen before the join to the participant dataset, so we bring through every single participant's demog data (DOB!)

I have ensured that:

- [ ] Code runs successfully in the development environment.
- [ ] New code is tested to prove that it meets the specificaiton. If not, justify reasoning.
- [ ] New code is documented using [type hinting](https://realpython.com/lessons/type-hinting/) and following the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) docstring format.
- [ ] New code follows the project naming standards.

## Overview of changes

<!---
Add any useful details about your changes here.
-->
