### PR TITLE
3251-fix-timestamp-bug

### DIFF
--- a/cishouseholds/pyspark_utils.py
+++ b/cishouseholds/pyspark_utils.py
@@ -126,6 +126,7 @@ def get_or_create_spark_session() -> SparkSession:
         .config("spark.sql.crossJoin.enabled", "true")
         .config("spark.sql.adaptive.enabled", "true")
         .config("spark.task.cpus", spark_session_options["spark.task.cpus"])
+        .config("spark.sql.session.timeZone", "UTC")
         .appName("cishouseholds")
         .enableHiveSupport()
         .getOrCreate()


### PR DESCRIPTION
This is aimed at addressing the bug whereby datetime objects shift by one hour when converted to timestamps within the first processing stage, i.e. between raw and transformed data.

In testing, the change that appears to fix the bug is explicitly setting the spark session configuration to be timezone of UTC.

The suspicion is that prior to explicitly setting the spark session to UTC, it must have assumed a London/Europe timezone and then converted it to UTC when converting strings to timestamps. During BST, London/Europe is UTC+1, so timestamps were shifted backward one hour (from, for example, yyyy-MM-ddT0:00 to yyyy-MM-d(d-1)T23:00). 