### PR TITLE
3273 develop documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/source/_autosummary/*
 
 # PyBuilder
 target/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,36 @@ Data engineering pipeline for the [Office for National Statistics coronavirus (C
 
 **Please note that this project is open for external reuse and review but closed for contribution.**
 
+```mermaid
+flowchart LR
+    SP_1[Copy Table] --> SP_2[Lookup CSVs to Tables]
+    SP_2 --> IOP_1(CRIS ETL)
+    IOP_1 --> IOP_2(Participant ETL)
+    IOP_2 --> SP_3[Union Historical Visits]
+    SP_3 --> SP_4[Join Participant ID]
+    SP_4 --> TA_1{Visit Transforms}
+    TA_1 --> TA_2{Job Transforms}
+    TA_2 --> TA_3{Demogrpahic Transforms}
+    TA_3 --> TA_4{Filter Dataframe}
+    TA_4 --> SP_5[Validate Survey Responses]
+    SP_5 --> IOP_3(Output Report)
+    SP_5 --> IOP_4(Export Report)
+    SP_5 --> IOP_5(Export Data to Analysis)
+    subgraph Legend
+          direction LR
+        start1[ ] --> SP[Supporting Process] --> stop1[ ]
+        start2[ ] --> IOP(Input/Output Process) --> stop2[ ]
+        start3[ ] --> TA{Transform Actions} --> stop3[ ]
+    end
+classDef green fill:#9f6,stroke:#333,stroke-width:2px;
+classDef orange fill:#f96,stroke:#333,stroke-width:4px;
+classDef blue fill:#89CFF0,stroke:#333,stroke-width:4px;
+classDef empty height:0px;
+class SP,SP_1,SP_2,SP_3,SP_4,SP_5 green
+class IOP,IOP_1,IOP_2,IOP_3,IOP_4,IOP_5 orange
+class TA,TA_1,TA_2,TA_3,TA_4 blue
+class start1,start2,start3,stop1,stop2,stop3 empty
+```
 
 ## Directories and files of note
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<img src="https://github.com/datasciencecampus/awesome-campus/blob/master/ons_logo.png">
+
+![Python Version](https://img.shields.io/badge/Python-3.6.8-blue.svg)
+[![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+[![status: active](https://github.com/GIScience/badges/raw/master/status/active.svg)](https://github.com/GIScience/badges#active)
+
 # CIS Households
 
 Data engineering pipeline for the [Office for National Statistics coronavirus (COVID-19) Infection Survey (CIS)](https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/bulletins/coronaviruscovid19infectionsurveypilot/previousReleases).

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@
 
 # CIS Households
 
-This repository contains the data engineering pipeline for the Office for National Statistics [COVID-19 and Respiratory Infections Survey (CRIS)](https://www.ons.gov.uk/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/covid19andrespiratoryinfectionssurveycris/aboutthestudy).
+This repository contains the data engineering pipeline for the Office for National Statistics' [COVID-19 and Respiratory Infections Survey (CRIS)](https://www.ons.gov.uk/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/covid19andrespiratoryinfectionssurveycris/aboutthestudy).
 
 This pipeline was developed and used in production for the predecessor survey to CRIS, the [Coronavirus (COVID-19) Infection Survey (CIS)](https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/bulletins/coronaviruscovid19infectionsurveypilot/previousReleases), and is in the process of being updated for CRIS.
 
+**A note around terminology:** 'PMH' and 'CRIS' are used interchangeably throughout this repository, but both refer to the successor to CIS.
 
 **Please note that this project is open for external reuse and review but closed for contribution.**
 
@@ -36,7 +37,7 @@ flowchart TD
     SP_3 --> SP_4[Join Participant ID]
     SP_4 --> TA_1{{Visit Transforms}}
     TA_1 --> TA_2{{Job Transforms}}
-    TA_2 --> TA_3{{Demogrpahic Transforms}}
+    TA_2 --> TA_3{{Demographic Transforms}}
     TA_3 --> TA_4{{Filter Dataframe}}
     TA_4 --> SP_5[Validate Survey Responses]
     SP_5 --> IOP_3(Output Report)
@@ -63,27 +64,29 @@ class data_1,data_2,DAT data
 
 ## Directories and files of note
 
-The hierarchy of folders (packages and subpackages) generally reflects how specific and abstract the code is. Code that is lower-level in abstraction and is more project-specific will sit deeper in the hierarchy.
+The hierarchy of folders (packages and sub-packages) generally reflects how specific and abstract the code is. Code that is lower-level in abstraction and is more project-specific will sit deeper in the hierarchy.
 
 Modules in the package are named semantically, so describe the types of operations that their contents perform.
 
 Descriptions of project directories and other significant files:
 * `cishouseholds/` - the core package in project. Code that is not project specific sits in the modules directly under this directory (i.e. data engineering functions and spark/hdf utilities that could be used in other projects)
-    * `cishouseholds/pipeline` - code that is specific to the project sits within this sub-package
+    * `cishouseholds/pipeline` - the primary body of code for the pipeline sits within this sub-package
         * `cishouseholds/pipeline/run.py` - the pipeline entry-point, which is executed to run the pipeline. This file assumes the presence of the necessary configuration YAML files.
         * `cishouseholds/pipeline/pipeline_stages.py` - contains the definitions of most pipeline stages (except for input file processing stage; see `cishouseholds/pipeline/input_file_stages.py`), which are the highest level groups of logic in the form of an ETL process. In practice, the execution and ordering of these stages is determined by the configuration YAML files.
         * `cishouseholds/pipeline/input_file_stages.py` - pipeline stages for processing input data files are configured here, using a reusable function factory
-        * `cishouseholds/pipeline/pre_union_transformations.py` - functions containing the transformation logic of the pre-union pipeline stages. These exist to allow us to integration test the transformations independents of the extract and load parts of the stages. Usually includes calls to multiple low-level functions
         * `cishouseholds/pipeline/lookup_and_regex_transformations.py` - functions containing the transformation logic of the lookup and regex based pipeline stages. These exist to allow us to integration test the transformations independents of the extract and load parts of the stages. Usually includes calls to multiple low-level functions
         * `cishouseholds/pipeline/post_union_transformations.py` - functions containing the transformation logic of the post-union pipeline stages. These exist to allow us to integration test the transformations independents of the extract and load parts of the stages. Usually includes calls to multiple low-level functions
         * `cishouseholds/pipeline/manifest.py` - a class used to generate a manifest file to trigger automated export of data produced by the pipeline
+        * `cishouseholds/pipeline/version_specific_processing` - sub-package containing the processing logic required for each version of the survey in order to harmonise the data before unioning together into a single set of survey responses
+    * `cishouseholds/phm` - sub-package of code added specifically to handle new questions and responses and structures introduced in CRIS/PHM (i.e. as opposed to historic CIS responses).
+    * `cishouseholds/regex` - sub-package of scripts containing regular expression code for handling textual survey responses. These are designed for pattern matching and categorising text field responses in relation to participant occupations, healthcare roles and vaccine information.
 * `docs/` - package documentation that is built and hosted as HTML by Github Actions based on the `main` branch code. See [documentation for sphinx for updating or building docs manually](https://www.sphinx-doc.org/en/master/)
-* `dummy_data_generation/` - dummy data schemata and functions to generate datesets. Used in regression tests for input processing functions
+* `dummy_data_generation/` - dummy data schemata and functions to generate datasets. Used in regression tests for input processing functions
 * `tests/` - tests for the code under `cishouseholds/`. Roughly follows the structure of the package, but has become out of date during refactors over time. Searching for references to the current function name is the most reliable way to identify associated tests
     * `tests/conftest.py` - reusable functions and pytest fixtures that can be accessed by any pytest tests
 * `CONTRIBUTING.md` - general guidance for contributing to the project
 * `Jenkinsfile` - config for Jenkins pipeline that detects new version tags (git tags) and deploys the built package to Artifactory
-* `.github/workflows` - configs for Github Actions
+* `.github/workflows` - configuration set-ups for the Github Actions associated with this repo - including building the documentation
 
 # Office for National Statistics
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,43 @@
 <img src="https://github.com/datasciencecampus/awesome-campus/blob/master/ons_logo.png">
 
 ![Python Version](https://img.shields.io/badge/Python-3.6.8-blue.svg)
+[![PySpark version](https://img.shields.io/badge/PySpark-2.4-blue)](https://spark.apache.org/docs/latest/api/python/)
 [![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![status: active](https://github.com/GIScience/badges/raw/master/status/active.svg)](https://github.com/GIScience/badges#active)
 
 # CIS Households
 
 This repository contains the data engineering pipeline for the Office for National Statistics [COVID-19 and Respiratory Infections Survey (CRIS)](https://www.ons.gov.uk/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/covid19andrespiratoryinfectionssurveycris/aboutthestudy).
 
-This pipeline was developed and used in production for the predecessor survey to CRIS, the [Coronavirus (COVID-19) Infection Survey (CIS)](https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/bulletins/coronaviruscovid19infectionsurveypilot/previousReleases), and is in the process of being upated for CRIS.
+This pipeline was developed and used in production for the predecessor survey to CRIS, the [Coronavirus (COVID-19) Infection Survey (CIS)](https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/bulletins/coronaviruscovid19infectionsurveypilot/previousReleases), and is in the process of being updated for CRIS.
 
 
 **Please note that this project is open for external reuse and review but closed for contribution.**
 
-## Workflow
+# Workflow
 
-The following diagram provides a high level overview of the pipeline for CRIS.
+The overall pipeline takes the raw responses data from survey participants, combines these with the historical data from previous CIS and CRIS participant responses, applies any necessary transformations and generates an output data file for passing to a separate analysis pipeline.
+
+The pipeline is designed to be executed on a Spark cluster within a secure ONS infrastructure (DAP). All input and output data is strictly contained within that secure environment.
+
+The pipeline is structured by a series of defined "stages" which group functional chunks of code together. The sequential ordering of stages is controlled by configuration YAML files - allowing the execution of a particular stage to be adjusted and toggled on and off as desired. These configuration files are stored within the secure environment and are necessary to successfully execute this code.
+
+The following diagram provides a high level overview of these pipeline stages for CRIS.
 
 ```mermaid
-flowchart LR
-    SP_1[Copy Table] --> SP_2[Lookup CSVs to Tables]
+flowchart TD
+    data_1[(Raw\nParticipant\nData)] --> SP_1[Copy Table]
+    data_2[(CIS/CRIS\nHistorical\nData)] --> SP_3
+    SP_1--> SP_2[Lookup CSVs to Tables]
     SP_2 --> IOP_1(CRIS ETL)
     IOP_1 --> IOP_2(Participant ETL)
     IOP_2 --> SP_3[Union Historical Visits]
     SP_3 --> SP_4[Join Participant ID]
-    SP_4 --> TA_1{Visit Transforms}
-    TA_1 --> TA_2{Job Transforms}
-    TA_2 --> TA_3{Demogrpahic Transforms}
-    TA_3 --> TA_4{Filter Dataframe}
+    SP_4 --> TA_1{{Visit Transforms}}
+    TA_1 --> TA_2{{Job Transforms}}
+    TA_2 --> TA_3{{Demogrpahic Transforms}}
+    TA_3 --> TA_4{{Filter Dataframe}}
     TA_4 --> SP_5[Validate Survey Responses]
     SP_5 --> IOP_3(Output Report)
     SP_5 --> IOP_4(Export Report)
@@ -36,29 +46,32 @@ flowchart LR
           direction LR
         start1[ ] --> SP[Supporting Process] --> stop1[ ]
         start2[ ] --> IOP(Input/Output Process) --> stop2[ ]
-        start3[ ] --> TA{Transform Actions} --> stop3[ ]
+        start3[ ] --> TA{{Transform Actions}} --> stop3[ ]
+        DAT[(Input Data)] --> stop4[ ]
     end
-classDef green fill:#9f6,stroke:#333,stroke-width:2px;
-classDef orange fill:#f96,stroke:#333,stroke-width:4px;
-classDef blue fill:#89CFF0,stroke:#333,stroke-width:4px;
+classDef green fill:#2FAD43,stroke:#333,stroke-width:4px,color:#fff;
+classDef red fill:#CA3434,stroke:#333,stroke-width:4px,color:#fff;
+classDef blue fill:#2F6AAD,stroke:#333,stroke-width:4px,color:#fff;
+classDef data fill:#E9E074,stroke:#333,stroke-width:4px;
 classDef empty height:0px;
 class SP,SP_1,SP_2,SP_3,SP_4,SP_5 green
-class IOP,IOP_1,IOP_2,IOP_3,IOP_4,IOP_5 orange
+class IOP,IOP_1,IOP_2,IOP_3,IOP_4,IOP_5 red
 class TA,TA_1,TA_2,TA_3,TA_4 blue
-class start1,start2,start3,stop1,stop2,stop3 empty
+class start1,start2,start3,stop1,stop2,stop3,stop4 empty
+class data_1,data_2,DAT data
 ```
 
 ## Directories and files of note
 
-The heirarchy of folders (packages and subpackages) generaly reflects how specific and abstract the code is. Code that is lower-level in abstraction and is more project-specific will sit deeper in the heirarchy.
+The hierarchy of folders (packages and subpackages) generally reflects how specific and abstract the code is. Code that is lower-level in abstraction and is more project-specific will sit deeper in the hierarchy.
 
 Modules in the package are named semantically, so describe the types of operations that their contents perform.
 
 Descriptions of project directories and other significant files:
 * `cishouseholds/` - the core package in project. Code that is not project specific sits in the modules directly under this directory (i.e. data engineering functions and spark/hdf utilities that could be used in other projects)
     * `cishouseholds/pipeline` - code that is specific to the project sits within this sub-package
-        * `cishouseholds/pipeline/run.py` - the pipeline entry-point, which is executed to run the pipeline
-        * `cishouseholds/pipeline/pipeline_stages.py` - contains the definitions of most pipeline stages (exept for input file processing stage; see `cishouseholds/pipeline/input_file_stages.py`), which are the highest level groups of logic in the form of an ETL process
+        * `cishouseholds/pipeline/run.py` - the pipeline entry-point, which is executed to run the pipeline. This file assumes the presence of the necessary configuration YAML files.
+        * `cishouseholds/pipeline/pipeline_stages.py` - contains the definitions of most pipeline stages (except for input file processing stage; see `cishouseholds/pipeline/input_file_stages.py`), which are the highest level groups of logic in the form of an ETL process. In practice, the execution and ordering of these stages is determined by the configuration YAML files.
         * `cishouseholds/pipeline/input_file_stages.py` - pipeline stages for processing input data files are configured here, using a reusable function factory
         * `cishouseholds/pipeline/pre_union_transformations.py` - functions containing the transformation logic of the pre-union pipeline stages. These exist to allow us to integration test the transformations independents of the extract and load parts of the stages. Usually includes calls to multiple low-level functions
         * `cishouseholds/pipeline/lookup_and_regex_transformations.py` - functions containing the transformation logic of the lookup and regex based pipeline stages. These exist to allow us to integration test the transformations independents of the extract and load parts of the stages. Usually includes calls to multiple low-level functions
@@ -71,3 +84,19 @@ Descriptions of project directories and other significant files:
 * `CONTRIBUTING.md` - general guidance for contributing to the project
 * `Jenkinsfile` - config for Jenkins pipeline that detects new version tags (git tags) and deploys the built package to Artifactory
 * `.github/workflows` - configs for Github Actions
+
+# Office for National Statistics
+
+We are the UK’s largest independent producer of official statistics and its recognised national statistical institute. We are responsible for collecting and publishing statistics related to the economy, population and society at national, regional and local levels. We also conduct the census in England and Wales every 10 years.
+
+# Licence
+
+<!-- Unless stated otherwise, the codebase is released under [the MIT Licence][mit]. -->
+
+The code, unless otherwise stated, is released under [the MIT Licence][mit].
+
+The documentation for this work is subject to [© Crown copyright][copyright] and is available under the terms of the [Open Government 3.0][ogl] licence.
+
+[mit]: LICENCE
+[copyright]: http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/
+[ogl]: http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/

--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@
 
 # CIS Households
 
-Data engineering pipeline for the [Office for National Statistics coronavirus (COVID-19) Infection Survey (CIS)](https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/bulletins/coronaviruscovid19infectionsurveypilot/previousReleases).
+This repository contains the data engineering pipeline for the Office for National Statistics [COVID-19 and Respiratory Infections Survey (CRIS)](https://www.ons.gov.uk/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/covid19andrespiratoryinfectionssurveycris/aboutthestudy).
+
+This pipeline was developed and used in production for the predecessor survey to CRIS, the [Coronavirus (COVID-19) Infection Survey (CIS)](https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/bulletins/coronaviruscovid19infectionsurveypilot/previousReleases), and is in the process of being upated for CRIS.
+
 
 **Please note that this project is open for external reuse and review but closed for contribution.**
+
+## Workflow
+
+The following diagram provides a high level overview of the pipeline for CRIS.
 
 ```mermaid
 flowchart LR

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ flowchart TD
     TA_3 --> TA_4{{Filter Dataframe}}
     TA_4 --> SP_5[Validate Survey Responses]
     SP_5 --> IOP_3(Output Report)
-    SP_5 --> IOP_4(Export Report)
+    IOP_3 --> IOP_4(Export Report)
     SP_5 --> IOP_5(Export Data to Analysis)
     subgraph Legend
           direction LR

--- a/cishouseholds/__init__.py
+++ b/cishouseholds/__init__.py
@@ -1,1 +1,2 @@
+"""Data engineering pipeline for CRIS"""
 __version__ = "4.3.0-beta.0"

--- a/cishouseholds/__init__.py
+++ b/cishouseholds/__init__.py
@@ -1,3 +1,2 @@
 """Data engineering pipeline for CRIS"""
 __version__ = "4.4.0-beta.0"
-

--- a/cishouseholds/phm/__init__.py
+++ b/cishouseholds/phm/__init__.py
@@ -1,0 +1,1 @@
+"""Code added specifically to handle new questions and responses and structures introduced in CRIS/PHM"""

--- a/cishouseholds/pipeline/__init__.py
+++ b/cishouseholds/pipeline/__init__.py
@@ -1,3 +1,4 @@
+"""The primary body of code for the pipeline sits within this sub-package"""
 import os
 
 from pyspark.sql import DataFrame

--- a/cishouseholds/pipeline/version_specific_processing/__init__.py
+++ b/cishouseholds/pipeline/version_specific_processing/__init__.py
@@ -1,0 +1,1 @@
+"""Contains the processing logic required for each version of the survey in order to harmonise the data before unioning together into a single set of survey responses"""

--- a/cishouseholds/regex/__init__.py
+++ b/cishouseholds/regex/__init__.py
@@ -1,3 +1,6 @@
+"""Handles textual survey responses - regex designed for pattern matching and categorising text field responses in relation to participant occupations, healthcare roles and vaccine information."""
+
+
 def match_with_exclusions(patters_to_match, patterns_to_exclude=[]):
     if type(patters_to_match) != list:
         patters_to_match = [patters_to_match]

--- a/docs/source/_templates/custom-module-template.rst
+++ b/docs/source/_templates/custom-module-template.rst
@@ -1,0 +1,66 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Module Attributes
+
+   .. autosummary::
+      :toctree:
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+      :toctree:
+      :template: custom-class-template.rst
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :template: custom-module-template.rst
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,8 @@ templates_path = ["_templates"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "classic"
+#html_theme = "classic"
+html_theme = "pydata_sphinx_theme"
 
 html_theme_options = {
     "icon_links": [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,7 @@ templates_path = ["_templates"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-#html_theme = "classic"
+# html_theme = "classic"
 html_theme = "pydata_sphinx_theme"
 
 html_theme_options = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,14 +8,16 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../.."))
+sys.path.insert(0, os.path.abspath("../../cishouseholds"))
 # -- Project information -----------------------------------------------------
 
 project = "cishouseholds"
-copyright = "2022, CIS Development Team"
-author = "CIS Development Team"
+copyright = "2023, CRIS Development Team"
+author = "CRIS Development Team"
 
 
 # -- General configuration ---------------------------------------------------
@@ -23,7 +25,7 @@ author = "CIS Development Team"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "sphinx.ext.autosummary"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -33,7 +35,7 @@ templates_path = ["_templates"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "pydata_sphinx_theme"
+html_theme = "classic"
 
 html_theme_options = {
     "icon_links": [

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,8 +6,23 @@
 Welcome to cishouseholds's documentation!
 =========================================
 
+.. note::
+
+   This documentation is under active development.
+
+
+This is the documentation for the data engineering pipeline for the
+`Office for National Statistics coronavirus (COVID-19) Infection Survey (CIS) <https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/bulletins/coronaviruscovid19infectionsurveypilot/previousReleases>`_.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
-   pipeline_stages.rst
+   modules
+   pipeline_stages
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,31 @@
+======================
+Module Index and Docs
+======================
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+   :recursive:
+
+   cishouseholds
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+   :recursive:
+
+   cishouseholds.pipeline
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+   :recursive:
+
+   cishouseholds.regex
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+   :recursive:
+
+   cishouseholds.phm


### PR DESCRIPTION
This PR covers changes aimed at:

- expanding the auto-generated documentation through Sphinx to include all modular functions. Note: I did test this locally, but can't truly test this works within GitHub actions until merged into `main`.
- add details about the overall pipeline workflow to the repo README aimed at making a holistic understanding of the pipeline more accessible. The readme changes are bested reviewed [here ](https://github.com/ONS-SST/cis_households/tree/3273-develop-documentation#readme).