### PR TITLE
CISDP-3283 fix to carry forward for cris job variables

### DIFF
--- a/cishouseholds/pipeline/job_transformations.py
+++ b/cishouseholds/pipeline/job_transformations.py
@@ -23,7 +23,6 @@ from cishouseholds.pyspark_utils import get_or_create_spark_session
 
 def job_transformations(df: DataFrame):
     """apply all transformations in order related to a persons vocation."""
-    df = fill_forwards(df).custom_checkpoint()
     return df
 
 

--- a/tests/pipeline/test_fill_forwards_work.py
+++ b/tests/pipeline/test_fill_forwards_work.py
@@ -1,0 +1,36 @@
+import pyspark.sql.functions as F
+from chispa import assert_df_equality
+
+from cishouseholds.pipeline.job_transformations import fill_forwards
+
+
+def test_filling_forwards(spark_session):
+    input_df = spark_session.createDataFrame(
+        data=[
+            (1, "01-01-2022", "abc", "dce", "hospitality", None, "primary", None),
+            (2, "01-01-2022", "abc", "dce", "Healthcare", None, "secondary", "Yes"),
+            (3, "01-01-2022", "abc", "dce", "Health care", None, "other", "No"),
+            (4, "01-01-2022", "abc", "dce", "manufacturing", None, None, None),
+            (5, "01-01-2022", "abc", "dce", "Social care", None, None, "Yes"),
+            (6, "01-01-2022", "abc", "dce", "finance", None, "secondary", "No"),
+        ],
+        schema="""participant_id integer, visit_datetime string, work_main_job_title string, work_main_job_role string,
+                  work_sector string, work_sector_other string, work_health_care_area string,
+                  work_nursing_or_residential_care_home string""",
+    )
+    expected_df = spark_session.createDataFrame(
+        data=[
+            (1, "01-01-2022", "abc", "dce", "hospitality", None, None, None),
+            (2, "01-01-2022", "abc", "dce", "Healthcare", None, "secondary", "Yes"),
+            (3, "01-01-2022", "abc", "dce", "Health care", None, "other", "No"),
+            (4, "01-01-2022", "abc", "dce", "manufacturing", None, None, None),
+            (5, "01-01-2022", "abc", "dce", "Social care", None, None, "Yes"),
+            (6, "01-01-2022", "abc", "dce", "finance", None, None, None),
+        ],
+        schema="""participant_id integer, visit_datetime string, work_main_job_title string, work_main_job_role string,
+                  work_sector string, work_sector_other string, work_health_care_area string,
+                  work_nursing_or_residential_care_home string""",
+    )
+
+    output_df = fill_forwards(input_df)
+    assert_df_equality(expected_df, output_df, ignore_nullable=True)


### PR DESCRIPTION
<!---
Note: Your PR request title must start with the Jira ticket number and concisely describe your changes.
For example: "123 Added function to calculate age on a given date"
-->

## Pre-review checklist
1. Removed work variables from fill_forwards that are asked every in every window, limiting the fill forward only to those which are asked only when someone has changed their job (and hence there would be null values here). 
2. Added some cleaning after the fill forward to remove contradictory fields e.g. where someone once worked in health care and had a health care area of primary, but no longer works in healthcare - the healthcare area is set to null. Otherwise the last value is carried forward and is inconsistent with that row's job information. 

I have ensured that:

- [ ] Code runs successfully in the development environment.
- [ ] New code is tested to prove that it meets the specificaiton. If not, justify reasoning.
- [ ] New code is documented using [type hinting](https://realpython.com/lessons/type-hinting/) and following the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) docstring format.
- [ ] New code follows the project naming standards.

## Overview of changes

<!---
Add any useful details about your changes here.
-->
