### PR TITLE
3273 - follow-up fix to documentation build

### DIFF
--- a/cishouseholds/derive.py
+++ b/cishouseholds/derive.py
@@ -2405,14 +2405,14 @@ def regex_match_result(
 
     The Truth Table below shows how the final pattern matching result is arrived at.
 
-    +----------------------+----------------------+-----+
-    |positive_regex_pattern|negative_regex_pattern|final|
-    +----------------------+----------------------+-----+
-    |                  true|                  true|false|
-    |                  true|                 false| true|
-    |                 false|                  true|false|
-    |                 false|                 false|false|
-    +----------------------+----------------------+-----+
+    #+----------------------+----------------------+-----+
+    #|positive_regex_pattern|negative_regex_pattern|final|
+    #+----------------------+----------------------+-----+
+    #|                  true|                  true|false|
+    #|                  true|                 false| true|
+    #|                 false|                  true|false|
+    #|                 false|                 false|false|
+    #+----------------------+----------------------+-----+
 
     Parameters:
     -----------
@@ -2465,14 +2465,14 @@ def assign_regex_match_result(
 
     The Truth Table below shows how the final pattern matching result is assigned.
 
-    +----------------------+----------------------+-----+
-    |positive_regex_pattern|negative_regex_pattern|final|
-    +----------------------+----------------------+-----+
-    |                  true|                  true|false|
-    |                  true|                 false| true|
-    |                 false|                  true|false|
-    |                 false|                 false|false|
-    +----------------------+----------------------+-----+
+    #+----------------------+----------------------+-----+
+    #|positive_regex_pattern|negative_regex_pattern|final|
+    #+----------------------+----------------------+-----+
+    #|                  true|                  true|false|
+    #|                  true|                 false| true|
+    #|                 false|                  true|false|
+    #|                 false|                 false|false|
+    #+----------------------+----------------------+-----+
 
     Parameters:
     -----------


### PR DESCRIPTION
Adding some minor adjustments to attempt to correct the failed auto doc build. 

The errors generated by GitHub Actions were:
```
/home/runner/work/cis_households/cis_households/cishouseholds/derive.py:docstring of cishouseholds.derive.regex_match_result:17: CRITICAL: Unexpected section title.

Parameters:
-----------
/home/runner/work/cis_households/cis_households/cishouseholds/derive.py:docstring of cishouseholds.derive.regex_match_result:29: CRITICAL: Unexpected section title.
```
I suspect the usage of `---` symbols to create tables in some docstring were the cause of these critical fails. Specifically, these:

![image](https://github.com/ONS-SST/cis_households/assets/62939263/09d47711-ff5d-4ec6-a899-8bd839e01fc0)

Sphinx uses the `---` to find section headers (as per `parameters` above) when building the docs. Hopefully `#` will sufficiently mask these. However, can't test this until we deploy to `main`. 