### PR TITLE
3273  - autodoc documentation fix - attempt number two

### DIFF
--- a/cishouseholds/derive.py
+++ b/cishouseholds/derive.py
@@ -2414,8 +2414,8 @@ def regex_match_result(
     #|                 false|                 false|false|
     #+----------------------+----------------------+-----+
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     columns_to_check_in
         a list of columns in which to look for the `positive_regex_pattern`
     positive_regex_pattern
@@ -2426,8 +2426,8 @@ def regex_match_result(
         If True and `negative_regex_pattern` is not None, then result of applying positive_regex_pattern and
         negative_regex_pattern are turned in addition to the final result.
 
-    Returns:
-    --------
+    Returns
+    -------
     Column
         The final result of applying positive_regex_pattern and negative_regex_pattern (if given)
     Tuple[Column, Column, Column]
@@ -2474,8 +2474,8 @@ def assign_regex_match_result(
     #|                 false|                 false|false|
     #+----------------------+----------------------+-----+
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     df
         The input dataframe to process
     columns_to_check_in
@@ -2493,8 +2493,8 @@ def assign_regex_match_result(
     debug_mode:
         Only relevant when `column_name_to_assign` is not None - See `negative_regex_pattern` above.
 
-    See Also:
-    ---------
+    See Also
+    --------
     regex_match_result: `assign_regex_match_result` wraps around `regex_match_result`
     """
     match_result = regex_match_result(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -305,8 +305,8 @@ def prepare_regex_test_cases():
     def _prepare_regex_test_cases(test_data: Dict[str, List[str]]) -> List[Tuple[str, bool]]:
         """Convenience function to prepare regex test cases.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         test_data:
             A dictionary with two keys, "positive" & "negative" & a list of strings as values
         """


### PR DESCRIPTION
That last fix did not solve it. Now I suspect the problem (the same problem) is due to the usage of `:` in these two docstrings. i.e
```
Parameters:
-----------
```
instead of 
```
Parameters
----------
```
It is possible this is breaking the Sphinx build because it introduces conflict between the [Google](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) and [NumPy](https://numpydoc.readthedocs.io/en/latest/format.html) style of docstring. That is,  
```
Parameters:
  some_param
```
and
```
Parameters
----------
  some_param
```
respectively. 